### PR TITLE
fix microk8s playbook for using a mix of master/agent nodes

### DIFF
--- a/mojaloop/iac/playbooks/argomicrok8s_cluster_deploy.yaml
+++ b/mojaloop/iac/playbooks/argomicrok8s_cluster_deploy.yaml
@@ -9,50 +9,11 @@
   become: true
   roles:
     - role: mojaloop.iac.k8s_node_common
-    - role: mojaloop.iac.microk8s
-      vars:
-        microk8s_enable_HA: true
-        microk8s_group_HA: "master"
-        microk8s_group_WORKERS: "agent"
-        add_workers_to_hostfile: false
-        microk8s_plugins:
-          dns: "1.1.1.1"
-          ingress: false # Ingress controller for external access
-          metrics-server: true # K8s Metrics Server for API access to service metrics
-          rbac: true # Role-Based Access Control for authorisation
-          hostpath-storage: true # Storage class; allocates storage from host directory
-          registry: "size={{ registry_size }}" # Private image registry exposed on localhost:32000
-          dashboard: true # The Kubernetes dashboard
-          ambassador: false # Ambassador API Gateway and Ingress
-          cilium: false # SDN, fast with full network policy
-          fluentd: false # Elasticsearch-Fluentd-Kibana logging and monitoring
-          gpu: false # Automatic enablement of Nvidia CUDA
-          helm: false # Helm 2 - the package manager for Kubernetes
-          helm3: true # Helm 3 - Kubernetes package manager
-          istio: false # Core Istio service mesh services
-          jaeger: false # Kubernetes Jaeger operator with its simple config
-          knative: false # The Knative framework on Kubernetes.
-          kubeflow: false # Kubeflow for easy ML deployments
-          linkerd: false # Linkerd is a service mesh for Kubernetes and other frameworks
-          metallb: false # Loadbalancer for your Kubernetes cluster
-          multus: false # Multus CNI enables attaching multiple network interfaces to pods
-          prometheus: false # Prometheus operator for monitoring and logging
-          traefik: false # another ingress
-          portainer: false # Container management dashboard
-          keda: false # Kubernetes Event-driven Autoscaling operator.
-          kata: false # A secure container runtime with lightweight virtual machines
-          openebs: false # openebs storage
-          openfaas: false
 
 - hosts: agent
   become: true
   roles:
     - role: mojaloop.iac.k8s_node_common
-    - role: mojaloop.iac.microk8s
-      vars:
-        microk8s_enable_HA: true
-        microk8s_group_HA: "master"
-        microk8s_group_WORKERS: "agent"
 
 - hosts: master
   become: true
@@ -91,6 +52,15 @@
           kata: false # A secure container runtime with lightweight virtual machines
           openebs: false # openebs storage
           openfaas: false
+
+- hosts: agent
+  become: true
+  roles:
+    - role: mojaloop.iac.microk8s
+      vars:
+        microk8s_enable_HA: true
+        microk8s_group_HA: "master"
+        microk8s_group_WORKERS: "agent"
 
 - hosts: bastion
   become: true

--- a/mojaloop/iac/playbooks/argomicrok8s_cluster_deploy.yaml
+++ b/mojaloop/iac/playbooks/argomicrok8s_cluster_deploy.yaml
@@ -14,6 +14,7 @@
         microk8s_enable_HA: true
         microk8s_group_HA: "master"
         microk8s_group_WORKERS: "agent"
+        add_workers_to_hostfile: true
         microk8s_plugins:
           dns: "1.1.1.1"
           ingress: false # Ingress controller for external access

--- a/mojaloop/iac/playbooks/argomicrok8s_cluster_deploy.yaml
+++ b/mojaloop/iac/playbooks/argomicrok8s_cluster_deploy.yaml
@@ -14,7 +14,7 @@
         microk8s_enable_HA: true
         microk8s_group_HA: "master"
         microk8s_group_WORKERS: "agent"
-        add_workers_to_hostfile: true
+        add_workers_to_hostfile: false
         microk8s_plugins:
           dns: "1.1.1.1"
           ingress: false # Ingress controller for external access
@@ -53,6 +53,44 @@
         microk8s_enable_HA: true
         microk8s_group_HA: "master"
         microk8s_group_WORKERS: "agent"
+
+- hosts: master
+  become: true
+  roles:
+    - role: mojaloop.iac.microk8s
+      vars:
+        microk8s_enable_HA: true
+        microk8s_group_HA: "master"
+        microk8s_group_WORKERS: "agent"
+        add_workers_to_hostfile: true
+        microk8s_plugins:
+          dns: "1.1.1.1"
+          ingress: false # Ingress controller for external access
+          metrics-server: true # K8s Metrics Server for API access to service metrics
+          rbac: true # Role-Based Access Control for authorisation
+          hostpath-storage: true # Storage class; allocates storage from host directory
+          registry: "size={{ registry_size }}" # Private image registry exposed on localhost:32000
+          dashboard: true # The Kubernetes dashboard
+          ambassador: false # Ambassador API Gateway and Ingress
+          cilium: false # SDN, fast with full network policy
+          fluentd: false # Elasticsearch-Fluentd-Kibana logging and monitoring
+          gpu: false # Automatic enablement of Nvidia CUDA
+          helm: false # Helm 2 - the package manager for Kubernetes
+          helm3: true # Helm 3 - Kubernetes package manager
+          istio: false # Core Istio service mesh services
+          jaeger: false # Kubernetes Jaeger operator with its simple config
+          knative: false # The Knative framework on Kubernetes.
+          kubeflow: false # Kubeflow for easy ML deployments
+          linkerd: false # Linkerd is a service mesh for Kubernetes and other frameworks
+          metallb: false # Loadbalancer for your Kubernetes cluster
+          multus: false # Multus CNI enables attaching multiple network interfaces to pods
+          prometheus: false # Prometheus operator for monitoring and logging
+          traefik: false # another ingress
+          portainer: false # Container management dashboard
+          keda: false # Kubernetes Event-driven Autoscaling operator.
+          kata: false # A secure container runtime with lightweight virtual machines
+          openebs: false # openebs storage
+          openfaas: false
 
 - hosts: bastion
   become: true

--- a/mojaloop/iac/roles/microk8s/tasks/configure-HA.yml
+++ b/mojaloop/iac/roles/microk8s/tasks/configure-HA.yml
@@ -11,13 +11,12 @@
 
 - name: Enumerate all cluster worker hosts within the hosts file
   become: true
-  gather_facts: false
   blockinfile:
     dest: /etc/hosts
     marker: "# {mark} ANSIBLE MANAGED: microk8s WORKER Cluster Hosts"
     content: |
       {% for host in groups[microk8s_group_WORKERS] %}
-      {{ hostvars[host]['ansible_host'] }} {{ hostvars[host]['ansible_hostname'] }}
+      {{ hostvars[host].ansible_default_ipv4.address }} {{ hostvars[host].ansible_hostname }}
       {% endfor %}
   when: add_workers_to_hostfile
 

--- a/mojaloop/iac/roles/microk8s/tasks/configure-HA.yml
+++ b/mojaloop/iac/roles/microk8s/tasks/configure-HA.yml
@@ -16,7 +16,7 @@
     marker: "# {mark} ANSIBLE MANAGED: microk8s WORKER Cluster Hosts"
     content: |
       {% for host in groups[microk8s_group_WORKERS] %}
-      {{ hostvars[host].ansible_default_ipv4.address }} {{ hostvars[host].ansible_hostname }}
+      {{ hostvars[host].ansible_host }} {{ hostvars[host].ansible_hostname }}
       {% endfor %}
   when: add_workers_to_hostfile
 

--- a/mojaloop/iac/roles/microk8s/tasks/configure-HA.yml
+++ b/mojaloop/iac/roles/microk8s/tasks/configure-HA.yml
@@ -16,7 +16,7 @@
     marker: "# {mark} ANSIBLE MANAGED: microk8s WORKER Cluster Hosts"
     content: |
       {% for host in groups[microk8s_group_WORKERS] %}
-      {{ hostvars[host].ansible_host }} {{ hostvars[host].ansible_hostname }}
+      {{ hostvars[host]['ansible_default_ipv4']['address'] }} {{ hostvars[host]['ansible_hostname'] }}
       {% endfor %}
   when: add_workers_to_hostfile
 

--- a/mojaloop/iac/roles/microk8s/tasks/configure-HA.yml
+++ b/mojaloop/iac/roles/microk8s/tasks/configure-HA.yml
@@ -11,12 +11,13 @@
 
 - name: Enumerate all cluster worker hosts within the hosts file
   become: true
+  gather_facts: false
   blockinfile:
     dest: /etc/hosts
     marker: "# {mark} ANSIBLE MANAGED: microk8s WORKER Cluster Hosts"
     content: |
       {% for host in groups[microk8s_group_WORKERS] %}
-      {{ hostvars[host]['ansible_default_ipv4']['address'] }} {{ hostvars[host]['ansible_hostname'] }}
+      {{ hostvars[host]['ansible_host'] }} {{ hostvars[host]['ansible_hostname'] }}
       {% endfor %}
   when: add_workers_to_hostfile
 


### PR DESCRIPTION
after the microk8s fix for this issue: https://github.com/canonical/microk8s/issues/4345
we had to alter the playbook order to add the correct host entries in the master node /etc/hosts files.