### PR TITLE
limiting gitlab user permission

### DIFF
--- a/mojaloop/iac/roles/minio/templates/policy.json
+++ b/mojaloop/iac/roles/minio/templates/policy.json
@@ -6,9 +6,7 @@
          "Action": [
             "s3:*"
          ],
-         "Resource": [
-            "arn:aws:s3:::*"
-         ]
+         "Resource": "arn:aws:s3:::gitlab*"
       }
    ]
 }


### PR DESCRIPTION
- limiting gitlab user permission for accessing minio buckets , as we create more buckets in minio for loki and longhorn