### PR TITLE
rm coredns

### DIFF
--- a/mojaloop/iac/roles/netmaker/templates/netmaker.docker-compose.yml.j2
+++ b/mojaloop/iac/roles/netmaker/templates/netmaker.docker-compose.yml.j2
@@ -65,15 +65,15 @@ services:
     ports:
       - "80:80"
       - "443:443"
-  coredns:
-    container_name: coredns
-    image: coredns/coredns
-    command: -conf /root/dnsconfig/Corefile
-    depends_on:
-      - netmaker
-    restart: always
-    volumes:
-      - dnsconfig:/root/dnsconfig
+#  coredns:
+#    container_name: coredns
+#    image: coredns/coredns
+#    command: -conf /root/dnsconfig/Corefile
+#    depends_on:
+#      - netmaker
+#    restart: always
+#    volumes:
+#      - dnsconfig:/root/dnsconfig
   mq: # the mqtt broker for netmaker
     container_name: mq
     image: eclipse-mosquitto:2.0.15-openssl


### PR DESCRIPTION
coredns doesn't run as root so doesn't have access to file generated by netmaker, removing coredns since not used for now