### PR TITLE
Fix/iprod 736

### DIFF
--- a/mojaloop/iac/roles/k8s_node_common/tasks/main.yaml
+++ b/mojaloop/iac/roles/k8s_node_common/tasks/main.yaml
@@ -17,3 +17,8 @@
     name: multipathd
     state: restarted
   when: "'multipath-tools' in ansible_facts.packages and multipathconf.changed"
+
+- name: Install yq
+  become: true
+  snap:
+    name: yq

--- a/mojaloop/iac/roles/k8s_node_common/tasks/main.yaml
+++ b/mojaloop/iac/roles/k8s_node_common/tasks/main.yaml
@@ -17,8 +17,3 @@
     name: multipathd
     state: restarted
   when: "'multipath-tools' in ansible_facts.packages and multipathconf.changed"
-
-- name: Install yq
-  become: true
-  snap:
-    name: yq

--- a/mojaloop/iac/roles/microk8s/defaults/main.yml
+++ b/mojaloop/iac/roles/microk8s/defaults/main.yml
@@ -71,3 +71,4 @@ registry_mirror_port: 9000
 teardown: false
 microk8s_root_path: /var/snap/microk8s/
 longhorn_data_path: /var/lib/longhorn/
+microk8s_apiserver_port: 16443

--- a/mojaloop/iac/roles/microk8s/tasks/configure-HA.yml
+++ b/mojaloop/iac/roles/microk8s/tasks/configure-HA.yml
@@ -49,6 +49,12 @@
       command: "microk8s status --wait-ready"
       changed_when: false
 
+    - name: Create tmp kubeconfig file 
+      file:
+        path: /tmp/kubeconfig
+        state: touch
+      delegate_to: "{{ designated_host }}"
+      
     - name: Replace IP with LB in kubeconfig
       command: 'microk8s config view | sed "s/{{ ansible_default_ipv4.address }}/{{ kubeapi_loadbalancer_fqdn }}/" > /tmp/kubecfg'
       when: kubeapi_loadbalancer_fqdn != 'none'

--- a/mojaloop/iac/roles/microk8s/tasks/configure-HA.yml
+++ b/mojaloop/iac/roles/microk8s/tasks/configure-HA.yml
@@ -49,11 +49,6 @@
       command: "microk8s status --wait-ready"
       changed_when: false
 
-    - name: Replace IP with LB in kubeconfig
-      command: yq e -i  '.clusters[0].cluster.server = "https://{{kubeapi_loadbalancer_fqdn}}:{{microk8s_apiserver_port}}"' /root/.kube/config
-      delegate_to: "{{ designated_host }}"
-      delegate_facts: true
-
     - name: Fetch kubeconfig
       fetch:
         src: "/root/.kube/config"
@@ -61,6 +56,11 @@
         flat: yes
       delegate_to: "{{ designated_host }}"
       delegate_facts: true
+
+    - name: Replace IP with LB in kubeconfig
+      command: yq e -i  '.clusters[0].cluster.server = "https://{{kubeapi_loadbalancer_fqdn}}:{{microk8s_apiserver_port}}"' /root/.kube/config
+      delegate_to: localhost
+      delegate_facts: true      
 
     - name: Set the microk8s join command on the microk8s node
       command: "{{ microk8s_join_command.stdout }}"

--- a/mojaloop/iac/roles/microk8s/tasks/configure-HA.yml
+++ b/mojaloop/iac/roles/microk8s/tasks/configure-HA.yml
@@ -58,7 +58,7 @@
       delegate_facts: true
 
     - name: Replace IP with LB in kubeconfig
-      command: yq e -i  '.clusters[0].cluster.server = "https://{{kubeapi_loadbalancer_fqdn}}:{{microk8s_apiserver_port}}"' /root/.kube/config
+      command: yq e -i  '.clusters[0].cluster.server = "https://{{kubeapi_loadbalancer_fqdn}}:{{microk8s_apiserver_port}}"' "{{ kubeconfig_local_location }}/kubeconfig"
       delegate_to: localhost
       delegate_facts: true      
 

--- a/mojaloop/iac/roles/microk8s/tasks/configure-HA.yml
+++ b/mojaloop/iac/roles/microk8s/tasks/configure-HA.yml
@@ -54,16 +54,16 @@
         path: /tmp/kubeconfig
         state: touch
       delegate_to: "{{ designated_host }}"
-      
+
     - name: Replace IP with LB in kubeconfig
-      command: 'microk8s config view | sed "s/{{ ansible_default_ipv4.address }}/{{ kubeapi_loadbalancer_fqdn }}/" > /tmp/kubecfg'
+      command: 'microk8s config view | sed "s/{{ ansible_default_ipv4.address }}/{{ kubeapi_loadbalancer_fqdn }}/" > /tmp/kubeconfig'
       when: kubeapi_loadbalancer_fqdn != 'none'
       delegate_to: "{{ designated_host }}"
       delegate_facts: true
 
     - name: Fetch kubeconfig
       fetch:
-        src: "/tmp/kubecfg"
+        src: "/tmp/kubeconfig"
         dest: "{{ kubeconfig_local_location }}/kubeconfig"
         flat: yes
       delegate_to: "{{ designated_host }}"

--- a/mojaloop/iac/roles/microk8s/tasks/configure-HA.yml
+++ b/mojaloop/iac/roles/microk8s/tasks/configure-HA.yml
@@ -59,6 +59,7 @@
 
     - name: Replace IP with LB in kubeconfig
       command: yq e -i  '.clusters[0].cluster.server = "https://{{kubeapi_loadbalancer_fqdn}}:{{microk8s_apiserver_port}}"' "{{ kubeconfig_local_location }}/kubeconfig"
+      when: kubeapi_loadbalancer_fqdn != "none"
       delegate_to: localhost
       delegate_facts: true      
 

--- a/mojaloop/iac/roles/microk8s/tasks/configure-HA.yml
+++ b/mojaloop/iac/roles/microk8s/tasks/configure-HA.yml
@@ -49,19 +49,14 @@
       command: "microk8s status --wait-ready"
       changed_when: false
 
-    - name: Create tmp kubeconfig file 
-      file:
-        path: /tmp/kubeconfig
-        state: touch
-      delegate_to: "{{ designated_host }}"
-
     - name: Replace IP with LB in kubeconfig
-      command: 'microk8s config view | sed "s/{{ ansible_default_ipv4.address }}/{{ kubeapi_loadbalancer_fqdn }}/" > /tmp/kubeconfig'
-      when: kubeapi_loadbalancer_fqdn != 'none'
+      command: yq e -i  '.clusters[0].cluster.server = "https://{{kubeapi_loadbalancer_fqdn}}:{{microk8s_apiserver_port}}"' /root/.kube/config
+      delegate_to: "{{ designated_host }}"
+      delegate_facts: true
 
     - name: Fetch kubeconfig
       fetch:
-        src: "/tmp/kubeconfig"
+        src: "/root/.kube/config"
         dest: "{{ kubeconfig_local_location }}/kubeconfig"
         flat: yes
       delegate_to: "{{ designated_host }}"

--- a/mojaloop/iac/roles/microk8s/tasks/configure-HA.yml
+++ b/mojaloop/iac/roles/microk8s/tasks/configure-HA.yml
@@ -49,9 +49,15 @@
       command: "microk8s status --wait-ready"
       changed_when: false
 
+    - name: Replace IP with LB in kubeconfig
+      command: 'microk8s config view | sed "s/{{ ansible_default_ipv4.address }}/{{ kubeapi_loadbalancer_fqdn }}/" > /tmp/kubecfg'
+      when: kubeapi_loadbalancer_fqdn != 'none'
+      delegate_to: "{{ designated_host }}"
+      delegate_facts: true
+
     - name: Fetch kubeconfig
       fetch:
-        src: "/root/.kube/config"
+        src: "/tmp/kubecfg"
         dest: "{{ kubeconfig_local_location }}/kubeconfig"
         flat: yes
       delegate_to: "{{ designated_host }}"

--- a/mojaloop/iac/roles/microk8s/tasks/configure-HA.yml
+++ b/mojaloop/iac/roles/microk8s/tasks/configure-HA.yml
@@ -58,8 +58,6 @@
     - name: Replace IP with LB in kubeconfig
       command: 'microk8s config view | sed "s/{{ ansible_default_ipv4.address }}/{{ kubeapi_loadbalancer_fqdn }}/" > /tmp/kubeconfig'
       when: kubeapi_loadbalancer_fqdn != 'none'
-      delegate_to: "{{ designated_host }}"
-      delegate_facts: true
 
     - name: Fetch kubeconfig
       fetch:


### PR DESCRIPTION
The current kube config file contains the cluster server address value as a single ip which points to one of the masters in kubernetes cluster. This causes unavailability of kubernetes cluster for the clients using the above wrong kube config file. Even though kubernetes is still up and running with a different elected master , clients wont be able to access the kubernetes cluster. 

Tasks:

Change the microk8s playbook to put the load balancer address in place of cluster server, so that the client can connect to the cluster in case of master fail overs. 

Acceptance criteria:

Clients should be able to connect to the cluster in all fail over scenarios irrespective of which master is live.