### PR TITLE
refresh interval for argo-oidc external secret

### DIFF
--- a/mojaloop/iac/roles/argocd/templates/argo-oidc-secrets.yaml.j2
+++ b/mojaloop/iac/roles/argocd/templates/argo-oidc-secrets.yaml.j2
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: argo-oidc
 spec:
-  refreshInterval: 1h
+  refreshInterval: 5m
 
   secretStoreRef:
     kind: ClusterSecretStore


### PR DESCRIPTION
- This is part of cto-88 MR to iac-modules
- As part of making refreshInterval of externalSecrets to 5 mins, argo-oidc also will have the same setting