### PR TITLE
fix: avoid looping when GP fails

### DIFF
--- a/mojaloop/iac/roles/argocd/templates/argocd-cm-patch.yaml.j2
+++ b/mojaloop/iac/roles/argocd/templates/argocd-cm-patch.yaml.j2
@@ -79,3 +79,35 @@ data:
         hs.status = "Progressing"
         hs.message = "Waiting for VaultSecret"
         return hs
+
+    batch/Job:
+      health.lua: |
+        hs = {}
+        if obj.status ~= nil then
+          if obj.status.conditions ~= nil then
+            for i, condition in ipairs(obj.status.conditions) do
+              if condition.type == "Failed" and condition.status == "True" then
+                hs.status = "Degraded"
+                if obj.metadata.name == "moja-ml-ttk-test-val-gp" or obj.metadata.name == "moja-ml-ttk-test-setup" then
+                  hs.status = "Healthy"
+                end
+                hs.message = condition.message
+                return hs
+              end
+              if condition.type == "Complete" and condition.status == "True" then
+                hs.status = "Healthy"
+                hs.message = condition.message
+                return hs
+              end
+              if condition.type == "Suspended" then
+                hs.status = "Suspended"
+                hs.message = condition.message
+                return hs
+              end
+            end
+          end
+        end
+
+        hs.status = "Progressing"
+        hs.message = "Waiting for Job"
+        return hs


### PR DESCRIPTION
In cases where GP test fails, ArgoCD is retrying the setup and GP jobs in a loop for quite a long time after the sync is applied and before the next sync is attempted. Each loop takes ~ 1 hour and often ArgoCD ends up in a state in which it does not actually perform the continuous delivery it stands for. The reason for this behavior is that it considers the success of GP to be a required part of a successful sync, while in practice this job tests the functionality of Mojaloop, not the sync success. This PR resolves this issue by reporting a `Healthy` status for the GP jobs , even if they fail. The results can be seen below, where the left ArgoCD instance is without this fix, the right is with it. The one on the right is reported as an unsuccessful sync, while on the right is successfult.

![image](https://github.com/user-attachments/assets/53857f20-19ed-460d-a0c9-fc88b8597d36)

![image](https://github.com/user-attachments/assets/3e62110c-17fd-4a39-9098-ce7e1a51a1e3)
