### PR TITLE
Coredns nodecache

### DIFF
--- a/mojaloop/iac/playbooks/ccmicrok8s_cluster_deploy.yaml
+++ b/mojaloop/iac/playbooks/ccmicrok8s_cluster_deploy.yaml
@@ -25,6 +25,7 @@
         add_workers_to_hostfile: true
         microk8s_plugins:
           ingress: false # Ingress controller for external access
+          dns: false
           metrics-server: true # K8s Metrics Server for API access to service metrics
           rbac: true # Role-Based Access Control for authorisation
           hostpath-storage: true # Storage class; allocates storage from host directory

--- a/mojaloop/iac/roles/argocd/defaults/main.yaml
+++ b/mojaloop/iac/roles/argocd/defaults/main.yaml
@@ -26,3 +26,6 @@ kubernetes_oidc_k8s_admin_group: none
 kubernetes_oidc_enabled: false
 kubernetes_oidc_issuer: none
 kubernetes_oidc_client_id: none
+install_coredns: true
+coredns_localcache_version: "1.11.3"
+dns_bind_address: "169.254.20.10"

--- a/mojaloop/iac/roles/argocd/tasks/main.yaml
+++ b/mojaloop/iac/roles/argocd/tasks/main.yaml
@@ -73,6 +73,7 @@
     - argocd-server-patch
     - argocd-cmd-params-cm-patch
     - k8s-oidc-rbac
+    - coredns-nodecache
     #- coredns-values
 
 # - name: Install coredns
@@ -80,14 +81,10 @@
 #     helm repo add coredns https://coredns.github.io/helm
 #     helm --kubeconfig {{ kubeconfig_location }}/kubeconfig upgrade --install coredns coredns/coredns --version {{ coredns_version }} -n kube-system --create-namespace -f {{ argotmpvalues.path }}/coredns-values.yaml
 
-- name: Install nodelocal dns cache
+- name: Install coredns-nodecache  
   shell: |
-    curl -sL https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml \
-    | sed -e 's/__PILLAR__DNS__DOMAIN__/cluster.local/g' \
-    | sed -e "s/__PILLAR__DNS__SERVER__/$(kubectl --kubeconfig {{ kubeconfig_location }}/kubeconfig get service --namespace kube-system kube-dns -o jsonpath='{.spec.clusterIP}')/g" \
-    | sed -e 's/__PILLAR__LOCAL__DNS__/169.254.20.10/g' \
-    | kubectl --kubeconfig {{ kubeconfig_location }}/kubeconfig apply -f -
-  when: install_nodelocaldns
+    kubectl --kubeconfig {{ kubeconfig_location }}/kubeconfig apply -f {{ argotmpvalues.path }}/coredns-nodecache.yaml
+  when: install_coredns | bool
 
 - name: Install external-secrets
   shell: |

--- a/mojaloop/iac/roles/argocd/templates/coredns-nodecache.yaml.j2
+++ b/mojaloop/iac/roles/argocd/templates/coredns-nodecache.yaml.j2
@@ -1,0 +1,307 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: coredns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  - pods
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: coredns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: coredns
+subjects:
+- kind: ServiceAccount
+  name: coredns-nodecache
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coredns-nodecache
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-nodecache-primary
+  namespace: kube-system
+data:
+  Corefile: |
+    cluster.local:53 {
+        errors
+        cache {
+          success 9984 30
+          denial 9984 5
+          prefetch 3 60s 15%
+        }
+        reload
+        loop
+        bind {{ dns_bind_address }} # Set your cluster dns to this
+        nodecache skipteardown
+        template IN AAAA {
+          rcode NOERROR
+        }
+        kubernetes cluster.local
+        prometheus :9253
+        health {{ dns_bind_address }}:8080
+        }
+    in-addr.arpa:53 {
+        errors
+        cache 120
+        reload
+        loop
+        bind {{ dns_bind_address }}
+        nodecache skipteardown
+        template IN AAAA {
+          rcode NOERROR
+        }
+        forward . /etc/resolv.conf {
+          force_tcp
+        }
+        prometheus :9253
+        }
+    .:53 {
+        errors
+        cache {
+          prefetch 3 60s 15%
+        }
+        reload
+        loop
+        bind {{ dns_bind_address }}
+        nodecache skipteardown
+        template IN AAAA {
+          rcode NOERROR
+        }
+        forward . /etc/resolv.conf {
+          force_tcp
+        }
+        prometheus :9253
+        }
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: coredns-nodecache-primary
+  namespace: kube-system
+  labels:
+    k8s-app: coredns-nodecache
+    kubernetes.io/cluster-service: "true"
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+  selector:
+    matchLabels:
+      k8s-app: coredns-nodecache
+  template:
+    metadata:
+      labels:
+        k8s-app: coredns-nodecache
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccountName: coredns-nodecache
+      hostNetwork: true
+      dnsPolicy: Default
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: coredns-nodecache
+        image: contentful/coredns-nodecache:v{{ coredns_localcache_version }}
+        resources:
+          limits:
+            memory: 50Mi
+          requests:
+            cpu: 25m
+            memory: 5Mi
+        args:
+        - -conf
+        - /etc/coredns/Corefile
+        securityContext:
+          privileged: true
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        - containerPort: 9253
+          name: metrics
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            host: {{ dns_bind_address }}
+            path: /health
+            port: 8080
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+        volumeMounts:
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
+          readOnly: false
+        - name: config-volume
+          mountPath: /etc/coredns
+      volumes:
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+      - name: config-volume
+        configMap:
+          name: coredns-nodecache-primary
+          items:
+          - key: Corefile
+            path: Corefile
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-nodecache-secondary
+  namespace: kube-system
+data:
+  Corefile: |
+    cluster.local:53 {
+        errors
+        cache {
+          success 9984 30
+          denial 9984 5
+          prefetch 3 60s 15%
+        }
+        reload
+        loop
+        bind {{ dns_bind_address }} # Set your cluster dns to this
+        template IN AAAA {
+          rcode NOERROR
+        }
+        kubernetes cluster.local
+        prometheus :9254
+        health {{ dns_bind_address }}:8082
+        }
+    in-addr.arpa:53 {
+        errors
+        cache 120
+        reload
+        loop
+        bind {{ dns_bind_address }}
+        template IN AAAA {
+          rcode NOERROR
+        }
+        forward . /etc/resolv.conf {
+          force_tcp
+        }
+        prometheus :9254
+        }
+    .:53 {
+        errors
+        cache {
+          prefetch 3 60s 15%
+        }
+        reload
+        loop
+        bind {{ dns_bind_address }}
+        template IN AAAA {
+          rcode NOERROR
+        }
+        forward . /etc/resolv.conf {
+          force_tcp
+        }
+        prometheus :9254
+        }
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: coredns-nodecache-secondary
+  namespace: kube-system
+  labels:
+    k8s-app: coredns-nodecache
+    kubernetes.io/cluster-service: "true"
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+  selector:
+    matchLabels:
+      k8s-app: coredns-nodecache
+  template:
+    metadata:
+      labels:
+        k8s-app: coredns-nodecache
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccountName: coredns-nodecache
+      hostNetwork: true
+      dnsPolicy: Default
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: coredns-nodecache
+        image: contentful/coredns-nodecache:v{{ coredns_localcache_version }}
+        resources:
+          limits:
+            memory: 50Mi
+          requests:
+            cpu: 25m
+            memory: 5Mi
+        args:
+        - -conf
+        - /etc/coredns/Corefile
+        securityContext:
+          privileged: true
+        ports:
+        - containerPort: 9254
+          name: metrics
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            host: {{ dns_bind_address }}
+            path: /health
+            port: 8082
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+        volumeMounts:
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
+          readOnly: false
+        - name: config-volume
+          mountPath: /etc/coredns
+      volumes:
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+      - name: config-volume
+        configMap:
+          name: coredns-nodecache-secondary
+          items:
+          - key: Corefile
+            path: Corefile

--- a/mojaloop/iac/roles/cc_k8s/defaults/main.yaml
+++ b/mojaloop/iac/roles/cc_k8s/defaults/main.yaml
@@ -10,6 +10,9 @@ helmfile_version: "0.165.0"
 helm_version: "3.14.0"
 cluster_cloud_provider: "aws"
 netbird_build_server_client_version: "0.28.9"
+install_coredns: true
+coredns_localcache_version: "1.11.3"
+dns_bind_address: "169.254.20.10"
 #argo
 argocd_override:
 argocd_default:

--- a/mojaloop/iac/roles/cc_k8s/tasks/install.yaml
+++ b/mojaloop/iac/roles/cc_k8s/tasks/install.yaml
@@ -3,6 +3,12 @@
   register: argocdappexists
   ignore_errors: true
 
+- name: Install coredns-localcache
+  shell: |
+    export KUBECONFIG={{ kubeconfig_location }}/kubeconfig
+    kubectl apply -f {{ cctmpvalues.path }}/coredns-nodecache.yaml
+  when: install_coredns | bool
+
 - name: Install argocd
   shell: |
     export KUBECONFIG={{ kubeconfig_location }}/kubeconfig

--- a/mojaloop/iac/roles/cc_k8s/tasks/setup_prerequisites.yaml
+++ b/mojaloop/iac/roles/cc_k8s/tasks/setup_prerequisites.yaml
@@ -68,3 +68,8 @@
     dest: "{{ cctmpvalues.path }}/argocd/{{ item.path | regex_replace('\\.j2$', '') }}"
   with_filetree: "{{role_path}}/templates/argocd"
   when: item.state == 'file'
+
+- name: Upload coredns-localcache template files
+  template:
+    src: "coredns-nodecache.yaml.j2"
+    dest: "{{ cctmpvalues.path }}/coredns-nodecache.yaml"

--- a/mojaloop/iac/roles/cc_k8s/templates/coredns-nodecache.yaml.j2
+++ b/mojaloop/iac/roles/cc_k8s/templates/coredns-nodecache.yaml.j2
@@ -132,7 +132,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: coredns-nodecache
-        image: contentful/coredns-nodecache:{{ coredns_localcache_version }}
+        image: contentful/coredns-nodecache:v{{ coredns_localcache_version }}
         resources:
           limits:
             memory: 50Mi
@@ -265,7 +265,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: coredns-nodecache
-        image: contentful/coredns-nodecache:{{ coredns_localcache_version }}
+        image: contentful/coredns-nodecache:v{{ coredns_localcache_version }}
         resources:
           limits:
             memory: 50Mi

--- a/mojaloop/iac/roles/cc_k8s/templates/coredns-nodecache.yaml.j2
+++ b/mojaloop/iac/roles/cc_k8s/templates/coredns-nodecache.yaml.j2
@@ -1,0 +1,307 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: coredns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  - pods
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: coredns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: coredns
+subjects:
+- kind: ServiceAccount
+  name: coredns-nodecache
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coredns-nodecache
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-nodecache-primary
+  namespace: kube-system
+data:
+  Corefile: |
+    cluster.local:53 {
+        errors
+        cache {
+          success 9984 30
+          denial 9984 5
+          prefetch 3 60s 15%
+        }
+        reload
+        loop
+        bind {{ dns_bind_address }} # Set your cluster dns to this
+        nodecache skipteardown
+        template IN AAAA {
+          rcode NOERROR
+        }
+        kubernetes cluster.local
+        prometheus :9253
+        health {{ dns_bind_address }}:8080
+        }
+    in-addr.arpa:53 {
+        errors
+        cache 120
+        reload
+        loop
+        bind {{ dns_bind_address }}
+        nodecache skipteardown
+        template IN AAAA {
+          rcode NOERROR
+        }
+        forward . /etc/resolv.conf {
+          force_tcp
+        }
+        prometheus :9253
+        }
+    .:53 {
+        errors
+        cache {
+          prefetch 3 60s 15%
+        }
+        reload
+        loop
+        bind {{ dns_bind_address }}
+        nodecache skipteardown
+        template IN AAAA {
+          rcode NOERROR
+        }
+        forward . /etc/resolv.conf {
+          force_tcp
+        }
+        prometheus :9253
+        }
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: coredns-nodecache-primary
+  namespace: kube-system
+  labels:
+    k8s-app: coredns-nodecache
+    kubernetes.io/cluster-service: "true"
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+  selector:
+    matchLabels:
+      k8s-app: coredns-nodecache
+  template:
+    metadata:
+      labels:
+        k8s-app: coredns-nodecache
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccountName: coredns-nodecache
+      hostNetwork: true
+      dnsPolicy: Default
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: coredns-nodecache
+        image: contentful/coredns-nodecache:{{ coredns_localcache_version }}
+        resources:
+          limits:
+            memory: 50Mi
+          requests:
+            cpu: 25m
+            memory: 5Mi
+        args:
+        - -conf
+        - /etc/coredns/Corefile
+        securityContext:
+          privileged: true
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        - containerPort: 9253
+          name: metrics
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            host: {{ dns_bind_address }}
+            path: /health
+            port: 8080
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+        volumeMounts:
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
+          readOnly: false
+        - name: config-volume
+          mountPath: /etc/coredns
+      volumes:
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+      - name: config-volume
+        configMap:
+          name: coredns-nodecache-primary
+          items:
+          - key: Corefile
+            path: Corefile
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-nodecache-secondary
+  namespace: kube-system
+data:
+  Corefile: |
+    cluster.local:53 {
+        errors
+        cache {
+          success 9984 30
+          denial 9984 5
+          prefetch 3 60s 15%
+        }
+        reload
+        loop
+        bind {{ dns_bind_address }} # Set your cluster dns to this
+        template IN AAAA {
+          rcode NOERROR
+        }
+        kubernetes cluster.local
+        prometheus :9254
+        health {{ dns_bind_address }}:8082
+        }
+    in-addr.arpa:53 {
+        errors
+        cache 120
+        reload
+        loop
+        bind {{ dns_bind_address }}
+        template IN AAAA {
+          rcode NOERROR
+        }
+        forward . /etc/resolv.conf {
+          force_tcp
+        }
+        prometheus :9254
+        }
+    .:53 {
+        errors
+        cache {
+          prefetch 3 60s 15%
+        }
+        reload
+        loop
+        bind {{ dns_bind_address }}
+        template IN AAAA {
+          rcode NOERROR
+        }
+        forward . /etc/resolv.conf {
+          force_tcp
+        }
+        prometheus :9254
+        }
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: coredns-nodecache-secondary
+  namespace: kube-system
+  labels:
+    k8s-app: coredns-nodecache
+    kubernetes.io/cluster-service: "true"
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+  selector:
+    matchLabels:
+      k8s-app: coredns-nodecache
+  template:
+    metadata:
+      labels:
+        k8s-app: coredns-nodecache
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccountName: coredns-nodecache
+      hostNetwork: true
+      dnsPolicy: Default
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: coredns-nodecache
+        image: contentful/coredns-nodecache:{{ coredns_localcache_version }}
+        resources:
+          limits:
+            memory: 50Mi
+          requests:
+            cpu: 25m
+            memory: 5Mi
+        args:
+        - -conf
+        - /etc/coredns/Corefile
+        securityContext:
+          privileged: true
+        ports:
+        - containerPort: 9254
+          name: metrics
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            host: {{ dns_bind_address }}
+            path: /health
+            port: 8082
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+        volumeMounts:
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
+          readOnly: false
+        - name: config-volume
+          mountPath: /etc/coredns
+      volumes:
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+      - name: config-volume
+        configMap:
+          name: coredns-nodecache-secondary
+          items:
+          - key: Corefile
+            path: Corefile

--- a/mojaloop/iac/roles/eks_util/tasks/main.yaml
+++ b/mojaloop/iac/roles/eks_util/tasks/main.yaml
@@ -46,6 +46,14 @@
     dest: /usr/local/bin/kubectl
     mode: 0700
 
+- name: Remove eks coredns installation 
+  shell: |
+    export KUBECONFIG={{ kubeconfig_location }}/kubeconfig
+    kubectl --namespace kube-system delete deployment coredns
+    kubectl --namespace kube-system annotate --overwrite service kube-dns meta.helm.sh/release-name=coredns
+    kubectl --namespace kube-system annotate --overwrite service kube-dns meta.helm.sh/release-namespace=kube-system
+    kubectl --namespace kube-system label --overwrite service kube-dns app.kubernetes.io/managed-by=Helm
+
 - name: Save configmap
   copy:
     content: "{{ eks_post_install_config_map }}"

--- a/mojaloop/iac/roles/microk8s/defaults/main.yml
+++ b/mojaloop/iac/roles/microk8s/defaults/main.yml
@@ -83,3 +83,4 @@ kubernetes_oidc_groups_prefix: "oidc:"
 kubernetes_oidc_username_prefix: "oidc:"
 kubernetes_oidc_username_claim: "username"
 docker_registry_mirrors: ["docker.io", "ghcr.io", "quay.io", "k8s.gcr.io"]
+dns_bind_address: "169.254.20.10"

--- a/mojaloop/iac/roles/microk8s/tasks/addons.yml
+++ b/mojaloop/iac/roles/microk8s/tasks/addons.yml
@@ -20,6 +20,7 @@
   when:
     - item.status == 'disabled'
     - item.name in microk8s_plugins
+    - item.name != 'dns'    
     - microk8s_plugins[item.name]
 
 - name: disable addons
@@ -32,4 +33,5 @@
   when:
     - item.status == 'enabled'
     - item.name in microk8s_plugins
+    - item.name != 'dns'    
     - not microk8s_plugins[item.name]

--- a/mojaloop/iac/roles/microk8s/templates/microk8s-config.yaml.j2
+++ b/mojaloop/iac/roles/microk8s/templates/microk8s-config.yaml.j2
@@ -1,6 +1,6 @@
 # microk8s-config.yaml
 ---
 version: 0.1.0
-addons:
-  - name: dns
-    args: [{{ microk8s_dns_resolvers }}] 
+extraKubeletArgs:
+  --cluster-domain: cluster.local
+  --cluster-dns: {{ dns_bind_address }}


### PR DESCRIPTION
Deploy a custom version of CoreDNS in Kubernetes clusters, completely replacing the default CoreDNS installation provided by MicroK8s and EKS. The custom installation should ensure high availability, optimized performance, and local caching capabilities for DNS resolution, tailored to the specific needs of our infrastructure.
