### PR TITLE
appset tag

### DIFF
--- a/mojaloop/iac/roles/cc_k8s/templates/application_set/env-application-set.yaml.j2
+++ b/mojaloop/iac/roles/cc_k8s/templates/application_set/env-application-set.yaml.j2
@@ -22,7 +22,7 @@ spec:
       project: default
       sources:
       - repoURL: {{ fact_argo_merged_config.gitrepo_host_fqdn }}/{{ fact_argo_merged_config.gitrepo_owner }}/{{ fact_argo_merged_config.gitrepo_repo }}.git
-        targetRevision: {{ fact_argo_merged_config.apps['deploy_env'].sub_apps['config'].terraform_modules_tag }}
+        targetRevision: {{ fact_argo_merged_config.apps['deploy_env'].sub_apps['onboard'].terraform_modules_tag }}
         path: 'gitops/applications/base/deploy-env-onboard'
         plugin:
           name: envsubst
@@ -38,7 +38,7 @@ spec:
             - name: "deploy_env_onboard_app_sync_wave"
               value: "{{ fact_argo_merged_config.apps['deploy_env'].sub_apps['onboard'].sync_wave }}"
             - name: "deploy_env_onboard_terraform_modules_tag"
-              value: "{{ fact_argo_merged_config.apps['deploy_env'].sub_apps['config'].terraform_modules_tag }}"
+              value: "{{ fact_argo_merged_config.apps['deploy_env'].sub_apps['onboard'].terraform_modules_tag }}"
             - name: "zitadel_fqdn"
               value: "{{ fact_zitadel_fqdn }}"
             - name: "netbird_fqdn"
@@ -149,7 +149,7 @@ spec:
               value: "{{ fact_argo_merged_config.apps['deploy_env'].sub_apps['onboard'].dbaas_default_management_policy }}"
 
       - repoURL: {{ fact_argo_merged_config.gitrepo_host_fqdn }}/{{ fact_argo_merged_config.gitrepo_owner }}/{{ fact_argo_merged_config.gitrepo_repo }}.git
-        targetRevision: {{ fact_argo_merged_config.apps['deploy_env'].sub_apps['config'].terraform_modules_tag }}
+        targetRevision: {{ fact_argo_merged_config.apps['deploy_env'].sub_apps['onboard'].terraform_modules_tag }}
         path: 'gitops/applications/overlays/cloud_provider/{{ fact_cloud_platform }}/storage-provider/deploy-env-onboard'
         plugin:
           name: envsubst
@@ -163,7 +163,7 @@ spec:
             - name: "cluster_name"
               value: "{{ cluster_name }}"
             - name: "terraform_modules_tag"
-              value: "{{ fact_argo_merged_config.apps['deploy_env'].sub_apps['config'].terraform_modules_tag }}"
+              value: "{{ fact_argo_merged_config.apps['deploy_env'].sub_apps['onboard'].terraform_modules_tag }}"
             - name: "vault_domain"
               value: "{{ '{{' }} cat \"int.\" .env | nospace {{ '}}'}}"
             - name: "argocd_domain"


### PR DESCRIPTION
This pull request updates the `env-application-set.yaml.j2` template to consistently use the `onboard` sub-app's `terraform_modules_tag` instead of the `config` sub-app's tag for deploying environment onboarding components. This ensures that the correct version of Terraform modules is referenced across all relevant configuration sections.

Key changes to environment onboarding configuration:

* Updated `targetRevision` fields to reference `fact_argo_merged_config.apps['deploy_env'].sub_apps['onboard'].terraform_modules_tag` instead of the `config` sub-app in two places, ensuring the correct module version is used for onboarding. [[1]](diffhunk://#diff-663101865dbfe63bba42da4389e7c5016496ab368331a2979b5d9b12e13885edL25-R25) [[2]](diffhunk://#diff-663101865dbfe63bba42da4389e7c5016496ab368331a2979b5d9b12e13885edL152-R152)
* Updated environment variable assignments to use the `onboard` sub-app's `terraform_modules_tag` rather than the `config` sub-app, maintaining version consistency for onboarding deployments. [[1]](diffhunk://#diff-663101865dbfe63bba42da4389e7c5016496ab368331a2979b5d9b12e13885edL41-R41) [[2]](diffhunk://#diff-663101865dbfe63bba42da4389e7c5016496ab368331a2979b5d9b12e13885edL166-R166)