### PR TITLE
Feature/microk8s controlled upgrade

### DIFF
--- a/mojaloop/iac/roles/microk8s/defaults/main.yml
+++ b/mojaloop/iac/roles/microk8s/defaults/main.yml
@@ -6,6 +6,7 @@
 # version management
 microk8s_version: "1.31/stable"
 microk8s_disable_snap_autoupdate: false
+microk8s_allow_patch_updates: false
 
 # plugin configuration
 addons_to_disable: "dns,rook-ceph,metrics-server,dashboard,cert-manager,metallb,registry,hostpath-storage"

--- a/mojaloop/iac/roles/microk8s/tasks/install.yml
+++ b/mojaloop/iac/roles/microk8s/tasks/install.yml
@@ -44,6 +44,10 @@
   set_fact:
     fact_microk8s_needs_update: "{{ (not fact_microk8s_not_installed) and (fact_microk8s_installed_channel != microk8s_version) }}"
 
+- name: Set fact if microk8s refresh should run
+  set_fact:
+    fact_microk8s_refresh_requested: "{{ (not fact_microk8s_not_installed) and (fact_microk8s_needs_update or (microk8s_allow_patch_updates | bool)) }}"
+
 - name: Debug microk8s snap info and facts
   debug:
     msg:
@@ -52,6 +56,7 @@
       - "fact_microk8s_installed_channel: {{ fact_microk8s_installed_channel }}"
       - "fact_microk8s_not_installed: {{ fact_microk8s_not_installed }}"
       - "fact_microk8s_needs_update: {{ fact_microk8s_needs_update }}"
+      - "fact_microk8s_refresh_requested: {{ fact_microk8s_refresh_requested }}"
 
 - name: Install microk8s
   become: true
@@ -64,7 +69,7 @@
 - name: Update channel
   become: true
   ansible.builtin.command: snap refresh microk8s --channel={{ microk8s_version }}
-  when: fact_microk8s_needs_update
+  when: fact_microk8s_refresh_requested
 
 - name: Hold microk8s snap refresh
   become: true

--- a/mojaloop/iac/roles/microk8s/tasks/install.yml
+++ b/mojaloop/iac/roles/microk8s/tasks/install.yml
@@ -39,6 +39,9 @@
 - name: Extract microk8s channel from snap list
   set_fact:
     fact_microk8s_installed_channel_raw: "{{ microk8s_snap_list.stdout | regex_search('microk8s\\s+\\S+\\s+\\S+\\s+(\\S+)', '\\1') }}"
+
+- name: Normalize microk8s channel to string
+  set_fact:
     fact_microk8s_installed_channel: >-
       {{
         (fact_microk8s_installed_channel_raw is sequence and fact_microk8s_installed_channel_raw is not string)

--- a/mojaloop/iac/roles/microk8s/tasks/install.yml
+++ b/mojaloop/iac/roles/microk8s/tasks/install.yml
@@ -38,7 +38,12 @@
 
 - name: Extract microk8s channel from snap list
   set_fact:
-    fact_microk8s_installed_channel: "{{ microk8s_snap_list.stdout | regex_search('microk8s\\s+\\S+\\s+\\S+\\s+(\\S+)', '\\1') }}"
+    fact_microk8s_installed_channel_raw: "{{ microk8s_snap_list.stdout | regex_search('microk8s\\s+\\S+\\s+\\S+\\s+(\\S+)', '\\1') }}"
+    fact_microk8s_installed_channel: >-
+      {{
+        (fact_microk8s_installed_channel_raw is sequence and fact_microk8s_installed_channel_raw is not string)
+        | ternary(fact_microk8s_installed_channel_raw | first | default(''), fact_microk8s_installed_channel_raw | default(''))
+      }}
 
 - name: Set fact if microk8s needs update
   set_fact:
@@ -53,10 +58,12 @@
     msg:
       - "microk8s_snap_list.stdout: {{ microk8s_snap_list.stdout }}"
       - "microk8s_snap_list.stderr: {{ microk8s_snap_list.stderr }}"
+      - "fact_microk8s_installed_channel_raw: {{ fact_microk8s_installed_channel_raw }}"
       - "fact_microk8s_installed_channel: {{ fact_microk8s_installed_channel }}"
       - "fact_microk8s_not_installed: {{ fact_microk8s_not_installed }}"
       - "fact_microk8s_needs_update: {{ fact_microk8s_needs_update }}"
       - "fact_microk8s_refresh_requested: {{ fact_microk8s_refresh_requested }}"
+      - "microk8s_allow_patch_updates: {{ microk8s_allow_patch_updates }}"
 
 - name: Install microk8s
   become: true


### PR DESCRIPTION
Add microk8s_allow_patch_updates support to control snap refresh behavior on already-installed MicroK8s nodes.
Normalize channel extraction to avoid false mismatches